### PR TITLE
Codify model restrictions and defaults

### DIFF
--- a/src/resolution_functions/instrument_data/arcs.yaml
+++ b/src/resolution_functions/instrument_data/arcs.yaml
@@ -8,10 +8,12 @@ version:
             d_sample_detector: 3.0                  # Distance (x2) from sample to detector (m)
             aperture_width: 0.1751         # Width of aperture at moderator face (m)
             theta: -13.75                   # Angle beamline makes with moderator face (degrees)
-            default_e_init: 500  # meV
-            allowed_e_init: [ 20, 1500 ]  # meV
-            default_chopper_frequency: 300
-            allowed_chopper_frequencies: [60, 601, 60]
+            defaults:
+                e_init: 500  # meV
+                chopper_frequency: 300
+            restrictions:
+                e_init: [ 20, 1500 ]  # meV
+                chopper_frequency: [60, 601, 60]
             frequency_matrix: [[1]]
             moderator: &moderator
                 type: 1

--- a/src/resolution_functions/instrument_data/cncs.yaml
+++ b/src/resolution_functions/instrument_data/cncs.yaml
@@ -49,10 +49,14 @@ version:
             d_sample_detector: 3.5                  # Distance (x2) from sample to detector (m)
             aperture_width: 0.        # Width of aperture at moderator face (m)
             theta: 32.0                   # Angle beamline makes with moderator face (degrees)
-            default_e_init: 20  # meV
-            allowed_e_init: [ 0.5, 80 ]  # meV
-            default_chopper_frequency: [ 300, 60 ]
-            allowed_chopper_frequencies: [[60, 301, 60], [60, 301, 60]]
+            defaults:
+                e_init: 20  # meV
+                resolution_disk_frequency: 300
+                fermi_frequency: 60
+            restrictions:
+                e_init: [ 0.5, 80 ]  # meV
+                resolution_disk_frequency: [60, 301, 60]
+                fermi_frequency: [60, 301, 60]
             constant_frequencies: [0, 60, 60, 0]
             frequency_matrix:
                 [ [ 0, 1 ],                    #   f1: The frequency of the resolution chopper (Chopper 4)

--- a/src/resolution_functions/instrument_data/hyspec.yaml
+++ b/src/resolution_functions/instrument_data/hyspec.yaml
@@ -8,10 +8,12 @@ version:
             d_sample_detector: 4.5                  # Distance (x2) from sample to detector (m)
             aperture_width: 0.0         # Width of aperture at moderator face (m)
             theta: 32.0                   # Angle beamline makes with moderator face (degrees)
-            default_e_init: 30  # meV
-            allowed_e_init: [ 3.6, 61.0 ]  # meV
-            default_chopper_frequency: 180
-            allowed_chopper_frequencies: [60, 421, 60]
+            defaults:
+                e_init: 30  # meV
+                chopper_frequency: 180
+            restrictions:
+                e_init: [ 3.6, 61.0 ]  # meV
+                chopper_frequency: [60, 421, 60]
             frequency_matrix:
                 [ [ 0 ],
                   [ 0 ],

--- a/src/resolution_functions/instrument_data/lagrange.yaml
+++ b/src/resolution_functions/instrument_data/lagrange.yaml
@@ -32,5 +32,7 @@ version:
             AbINS_v1:
                 function: "discontinuous_polynomial"
                 citation: [""]
-                parameters: {}
+                parameters:
+                    defaults: {}
+                    restrictions: {}
                 configurations: *lagrange_configurations

--- a/src/resolution_functions/instrument_data/let.yaml
+++ b/src/resolution_functions/instrument_data/let.yaml
@@ -58,10 +58,14 @@ version:
             d_sample_detector: 3.5                  # Distance (x2) from sample to detector (m)
             aperture_width: 0.        # Width of aperture at moderator face (m)
             theta: 32.0                  # Angle beamline makes with moderator face (degrees)
-            default_e_init: 20  # meV
-            allowed_e_init: [ 0., 30. ]  # meV
-            default_chopper_frequency: [ 240, 120 ]
-            allowed_chopper_frequencies: [[10, 301, 10], [10, 301, 10]]
+            defaults:
+                e_init: 20  # meV
+                resolution_frequency: 240
+                pulse_remover_frequency: 120
+            restrictions:
+                e_init: [ 0., 30. ]  # meV
+                resolution_frequency: [10, 301, 10]
+                pulse_remover_frequency: [10, 301, 10]
             constant_frequencies: [0, 10, 0, 0, 0]
             source_frequency: 10   # Frequency of source (Hz)
             n_frame: 1  # Number of frames to calculate time-distance diagram for

--- a/src/resolution_functions/instrument_data/maps.yaml
+++ b/src/resolution_functions/instrument_data/maps.yaml
@@ -8,10 +8,12 @@ version:
             d_sample_detector: 6.0                  # Distance (x2) from sample to detector (m)
             aperture_width: 0.094         # Width of aperture at moderator face (m)
             theta: 32.0                   # Angle beamline makes with moderator face (degrees)
-            default_e_init: 500  # meV
-            allowed_e_init: [ 0, 2000 ]  # meV
-            default_chopper_frequency: 400
-            allowed_chopper_frequencies: [50, 601, 50]
+            defaults:
+                e_init: 500  # meV
+                chopper_frequency: 400
+            restrictions:
+                e_init: [ 0, 2000 ]  # meV
+                chopper_frequency: [50, 601, 50]
             frequency_matrix:
                 [[0, 1],                    # f1 is the Fermi frequency
                  [1, 0]]                    # f2 is the Disk frequency

--- a/src/resolution_functions/instrument_data/mari.yaml
+++ b/src/resolution_functions/instrument_data/mari.yaml
@@ -3,14 +3,17 @@ default_version: 'MARI'
 
 version:
     MARI:
+        restrictions: &mari_restrictions
+            e_init: [ 0, 2000 ]  # meV
+            chopper_frequency: [50, 601, 50]
         constants: &mari_constants
             d_chopper_sample: 1.689              # Distance (x1) from final chopper to sample (m)
             d_sample_detector: 4.022                  # Distance (x2) from sample to detector (m)
             aperture_width: 0.06667        # Width of aperture at moderator face (m)
             theta: 13.0                   # Angle beamline makes with moderator face (degrees)
-            default_e_init: 500  # meV
-            default_chopper_frequency: 400
-            allowed_chopper_frequencies: [50, 601, 50]
+            defaults:
+                e_init: 500  # meV
+                chopper_frequency: 400
             frequency_matrix:
                 [ [ 0 ],                       # Only the Fermi frequency should be variable
                   [ 1 ] ]
@@ -52,37 +55,39 @@ version:
                     radius: 49.0e-3  # m
                     rho: 1.300  # m
                     tjit: 0.0             # Jitter time (us)
-                    allowed_e_init: [0, 2000]  # meV
+                    restrictions: *mari_restrictions
                 B:
                     pslit: 1.140e-3  # m
                     radius: 49.0e-3  # m
                     rho: 0.82  # m
                     tjit: 0.0             # Jitter time (us)
-                    allowed_e_init: [0, 2000]  # meV
+                    restrictions: *mari_restrictions
                 C:
                     pslit: 1.520e-3          # Neutron transparent slit width (mm)
                     radius: 49.0e-3          # Chopper package radius (mm)
                     rho: 0.58            # Chopper package curvature (mm)
                     tjit: 0.0             # Jitter time (us)
-                    allowed_e_init: [0, 2000]  # meV
+                    restrictions: *mari_restrictions
                 G:
                     pslit: 0.380e-3          # Neutron transparent slit width (mm)
                     radius: 10.0e-3          # Chopper package radius (mm)
                     rho: 0.8            # Chopper package curvature (mm)
                     tjit: 0.0             # Jitter time (us)
-                    allowed_e_init: [ 0, 181 ]   # Limits on ei for this chopper (configuration Ei outside this will give error)
+                    restrictions:
+                        <<: *mari_restrictions
+                        e_init: [ 0, 181 ]   # Limits on ei for this chopper (configuration Ei outside this will give error)
                 R:
                     pslit: 1.143e-3          # Neutron transparent slit width (mm)
                     radius: 49.0e-3          # Chopper package radius (mm)
                     rho: 1.300           # Chopper package curvature (mm)
                     tjit: 0.0             # Jitter time (us)
-                    allowed_e_init: [0, 2000]  # meV
+                    restrictions: *mari_restrictions
                 S:
                     pslit: 2.280e-3  # m
                     radius: 49.0e-3  # m
                     rho: 1.300  # m
                     tjit: 0.0             # Jitter time (us)
-                    allowed_e_init: [ 0, 2000 ]  # meV
+                    restrictions: *mari_restrictions
         default_model: 'PyChop_fit'
         models:
             PyChop_fit: "PyChop_fit_v1"

--- a/src/resolution_functions/instrument_data/merlin.yaml
+++ b/src/resolution_functions/instrument_data/merlin.yaml
@@ -3,14 +3,16 @@ default_version: 'MERLIN'
 
 version:
     MERLIN:
+        restrictions: &merlin_restrictions
+            chopper_frequency: [50, 601, 50]
         constants: &constants
             d_chopper_sample: 1.925               # Distance (x1) from final chopper to sample (m)
             d_sample_detector: 2.5                  # Distance (x2) from sample to detector (m)
             aperture_width: 0.06667         # Width of aperture at moderator face (m)
             theta: 26.7                   # Angle beamline makes with moderator face (degrees)
-            default_e_init: 400  # meV
-            default_chopper_frequency: 400
-            allowed_chopper_frequencies: [50, 601, 50]
+            defaults:
+                e_init: 400  # meV
+                chopper_frequency: 400
             frequency_matrix:
                 [ [ 0 ],                       # Only the Fermi frequency should be variable
                   [ 1 ] ]
@@ -52,13 +54,17 @@ version:
                     radius: 5.0e-3  # m
                     rho: 1000  # m
                     tjit: 0.0             # Jitter time (us)
-                    allowed_e_init: [0, 181]
+                    restrictions:
+                        <<: *merlin_restrictions
+                        e_init: [0, 181]
                 S:
                     pslit: 2.280e-3  # m
                     radius: 49.0e-3  # m
                     rho: 1.300  # m
                     tjit: 0.0             # Jitter time (us)
-                    allowed_e_init: [ 7, 2000 ]  # meV
+                    restrictions:
+                        <<: *merlin_restrictions
+                        e_init: [ 7, 2000 ]  # meV
         default_model: 'PyChop_fit'
         models:
             PyChop_fit: "PyChop_fit_v1"

--- a/src/resolution_functions/instrument_data/panther.yaml
+++ b/src/resolution_functions/instrument_data/panther.yaml
@@ -18,6 +18,8 @@ version:
                 citation: [""]
                 configurations: {}
                 parameters:
+                    defaults: { }
+                    restrictions: { }
                     abs:
                         [9.776165626074981, 0.023616411911882462, 0.0006472263718719711, 1.4819832651359686e-06]  # abs_meV
                     ei_dependence:

--- a/src/resolution_functions/instrument_data/sequoia.yaml
+++ b/src/resolution_functions/instrument_data/sequoia.yaml
@@ -8,10 +8,12 @@ version:
             d_sample_detector: 5.5                  # Distance (x2) from sample to detector (m)
             aperture_width: 0.050         # Width of aperture at moderator face (m)
             theta: -13.75                   # Angle beamline makes with moderator face (degrees)
-            default_e_init: 500  # meV
-            allowed_e_init: [ 4, 6000 ]  # meV
-            default_chopper_frequency: 300
-            allowed_chopper_frequencies: [60, 601, 60]
+            defaults:
+                e_init: 500  # meV
+                chopper_frequency: 300
+            restrictions:
+                e_init: [ 4, 6000 ]  # meV
+                chopper_frequency: [60, 601, 60]
             frequency_matrix: [[1]]
             moderator: &moderator
                 type: 1

--- a/src/resolution_functions/instrument_data/tosca.yaml
+++ b/src/resolution_functions/instrument_data/tosca.yaml
@@ -4,6 +4,8 @@ default_version: 'TOSCA'
 version:
     TFXA:
         constants: &tfxa_constants
+            defaults: {}
+            restrictions: {}
             final_neutron_energy: 32.0  # Final energy on the crystal analyser in cm-1
             scattering_angle: 2.356  # Angle of the crystal analyser radians (NO LONGER USED)
             energy_bin_width: 1.0  # Default bin width in wavenumber
@@ -35,6 +37,8 @@ version:
                 configurations: *tfxa_configurations
     TOSCA1:
         constants: &tosca1_constants
+            defaults: {}
+            restrictions: {}
             final_neutron_energy: 32.0  # Final energy on the crystal analyser in cm-1
             scattering_angle: 2.356  # Angle of the crystal analyser radians (NO LONGER USED)
             energy_bin_width: 1.0  # Default bin width in wavenumber
@@ -67,6 +71,8 @@ version:
                 configurations: *tosca1_configurations
     TOSCA:
         constants: &tosca_constants
+            defaults: {}
+            restrictions: {}
             primary_flight_path: 17.  # m
             primary_flight_path_uncertainty: 0.0021  # m
             sample_thickness: 0.002  # m
@@ -94,6 +100,8 @@ version:
                 citation: [""]
                 #original_parameters: [2.5, 0.005, 0.0000001] wavenumber
                 parameters:
+                    defaults: {}
+                    restrictions: {}
                     fit: [ 0.3099604960830007, 0.005, 8.065543937349209e-07 ]  # meV
                 configurations: {}
             book: "book_v1"

--- a/src/resolution_functions/instrument_data/vision.yaml
+++ b/src/resolution_functions/instrument_data/vision.yaml
@@ -4,6 +4,8 @@ default_version: 'VISION'
 version:
     VISION:
         constants: &vision_constants
+            defaults: {}
+            restrictions: {}
             primary_flight_path: 15.  # m
             primary_flight_path_uncertainty: null
             sample_thickness: 0.002  # m

--- a/src/resolution_functions/models/model_base.py
+++ b/src/resolution_functions/models/model_base.py
@@ -216,7 +216,7 @@ class InstrumentModel(ABC):
                 except KeyError:
                     raise InvalidInputError(f'Model "{type(self).__name__}" does not have a default'
                                             f' value for the "{name}" setting, so one must be '
-                                            'provided by the user.')
+                                            'provided by the user.') from None
                 continue
 
             try:

--- a/src/resolution_functions/models/model_base.py
+++ b/src/resolution_functions/models/model_base.py
@@ -216,7 +216,7 @@ class InstrumentModel(ABC):
                 except KeyError:
                     raise InvalidInputError(f'Model "{type(self).__name__}" does not have a default'
                                             f' value for the "{name}" setting, so one must be '
-                                            f'provided by the user.')
+                                            'provided by the user.')
                 continue
 
             try:
@@ -230,11 +230,13 @@ class InstrumentModel(ABC):
                     if not restriction[0] <= setting <= restriction[1]:
                         raise InvalidInputError(f'The provided value for the "{name}" setting '
                                                 f'({setting}) must be within the {restriction} '
-                                                f'boundaries.')
-                elif setting not in range(*restriction):
-                    raise InvalidInputError(f'The provided value for the "{name}" setting '
-                                            f'({setting}) must be one of the following values: '
-                                            f'{list(range(*restriction))}')
+                                                'boundaries.')
+                else:
+                    start, stop, step = restriction
+                    if setting not in range(start, stop, step):
+                        raise InvalidInputError(f'The provided value for the "{name}" setting '
+                                                f'({setting}) must be one of the following values: '
+                                                f'{list(range(*restriction))}')
             elif setting not in restriction:
                 raise InvalidInputError(f'The provided value for the "{name}" setting ({setting}) '
                                         f'must be one of the following values: {restriction}')

--- a/src/resolution_functions/models/model_base.py
+++ b/src/resolution_functions/models/model_base.py
@@ -82,43 +82,17 @@ class ModelData(ABC):
         The citation for a particular model. Please use this to look up more details and cite the
         model.
     restrictions
+        All constraints that the model places on the :term:`settings<setting>`. If the value is a
+        `list`, this signifies the `range` style (start, stop, step) tuple, and if it is a `set`, it
+        is a set of explicitly allowed values.
     defaults
+        The default values for the :term:`settings<setting>`, used when a value is not provided when
+        creating the model.
     """
     function: str
     citation: list[str]
-
-    @property
-    def restrictions(self) -> dict[str, list[int | float]]:
-        """
-        The restrictions that the corresponding :term:`model` places on each :term:`setting`.
-
-        This is provided via a dictionary where the keys are the name of the :term:`setting`,
-        and the values are the restriction for that :term:`setting`. The restrictions can be the
-        upper or lower bounds, or even a list of allowed values. If an invalid input is passed in, a
-        `InvalidInputError` will be raised.
-
-        Returns
-        -------
-        restrictions
-            A mapping of :term:`setting` to its corresponding restriction.
-        """
-        return {}
-
-    @property
-    def defaults(self) -> dict[str, Any]:
-        """
-        The defaults for each :term:`setting` for the corresponding :term:`model`.
-
-        This is provided as a dictionary where the keys are the name of the :term:`setting`,
-        and the values are the default for that :term:`setting`. The default will be used when a
-        particular :term:`setting` is not passed in to the :term:`model`
-
-        Returns
-        -------
-        defaults
-            A mapping of :term:`settings<setting>` to their corresponding default values.
-        """
-        return {}
+    defaults: dict[str, int | float]
+    restrictions: dict[str, list[int | float], set[int | float]]
 
 
 class InstrumentModel(ABC):

--- a/src/resolution_functions/models/model_base.py
+++ b/src/resolution_functions/models/model_base.py
@@ -187,3 +187,58 @@ class InstrumentModel(ABC):
             The citation.
         """
         return self._citation
+
+    def _validate_settings(self,
+                           model_data: ModelData,
+                           settings: dict[str, int | float | None]
+                           ) -> dict[str, int | float]:
+        """
+        Validates the user-provided `settings` against the models restrictions and fills in defaults
+
+        Parameters
+        ----------
+        model_data
+            The data associated with the model for a given version of a given instrument.
+        settings
+            The user-provided :term:`settings<setting>`
+
+        Returns
+        -------
+        validated_settings
+            The user-provided settings that comply with the model's restrictions and with any `None`
+            values replaced with defaults.
+        """
+        out = {}
+        for name, setting in settings.items():
+            if setting is None:
+                try:
+                    out[name] = model_data.defaults[name]
+                except KeyError:
+                    raise InvalidInputError(f'Model "{type(self).__name__}" does not have a default'
+                                            f' value for the "{name}" setting, so one must be '
+                                            f'provided by the user.')
+                continue
+
+            try:
+                restriction = model_data.restrictions[name]
+            except KeyError:
+                out[name] = setting
+                continue
+
+            if isinstance(restriction, list):
+                if len(restriction) == 2:
+                    if not restriction[0] <= setting <= restriction[1]:
+                        raise InvalidInputError(f'The provided value for the "{name}" setting '
+                                                f'({setting}) must be within the {restriction} '
+                                                f'boundaries.')
+                elif setting not in range(*restriction):
+                    raise InvalidInputError(f'The provided value for the "{name}" setting '
+                                            f'({setting}) must be one of the following values: '
+                                            f'{list(range(*restriction))}')
+            elif setting not in restriction:
+                raise InvalidInputError(f'The provided value for the "{name}" setting ({setting}) '
+                                        f'must be one of the following values: {restriction}')
+
+            out[name] = setting
+
+        return out

--- a/src/resolution_functions/models/panther_abins.py
+++ b/src/resolution_functions/models/panther_abins.py
@@ -34,6 +34,13 @@ class PantherAbINSModelData(ModelData):
         The name of the function, i.e. the alias for `PantherAbINSModel`.
     citation
         The citation for the model. Please use this to look up more details and cite the model.
+    restrictions
+        All constraints that the model places on the :term:`settings<setting>`. If the value is a
+        `list`, this signifies the `range` style (start, stop, step) tuple, and if it is a `set`, it
+        is a set of explicitly allowed values.
+    defaults
+        The default values for the :term:`settings<setting>`, used when a value is not provided when
+        creating the model.
     abs
         Polynomial coefficients for the energy transfer (frequencies) polynomial.
     ei_dependence
@@ -41,8 +48,6 @@ class PantherAbINSModelData(ModelData):
     ei_energy_product
         Polynomial coefficients for the product of initial energy and energy transfer (frequencies)
         polynomial.
-    restrictions
-    defaults
     """
     abs: list[float]
     ei_dependence: list[float]

--- a/src/resolution_functions/models/polynomial.py
+++ b/src/resolution_functions/models/polynomial.py
@@ -34,10 +34,15 @@ class PolynomialModelData(ModelData):
         The name of the function, i.e. the alias for `PolynomialModel1D`.
     citation
         The citation for the model. Please use this to look up more details and cite the model.
+    restrictions
+        All constraints that the model places on the :term:`settings<setting>`. If the value is a
+        `list`, this signifies the `range` style (start, stop, step) tuple, and if it is a `set`, it
+        is a set of explicitly allowed values.
+    defaults
+        The default values for the :term:`settings<setting>`, used when a value is not provided when
+        creating the model.
     fit
         Polynomial coefficients.
-    restrictions
-    defaults
     """
     fit: list[float]
 
@@ -126,6 +131,13 @@ class DiscontinuousPolynomialModelData(ModelData):
         The name of the function, i.e. the alias for `DiscontinuousPolynomialModel1D`.
     citation
         The citation for the model. Please use this to look up more details and cite the model.
+    restrictions
+        All constraints that the model places on the :term:`settings<setting>`. If the value is a
+        `list`, this signifies the `range` style (start, stop, step) tuple, and if it is a `set`, it
+        is a set of explicitly allowed values.
+    defaults
+        The default values for the :term:`settings<setting>`, used when a value is not provided when
+        creating the model.
     fit
         Polynomial coefficients.
     low_energy_cutoff
@@ -140,8 +152,6 @@ class DiscontinuousPolynomialModelData(ModelData):
     high_energy_resolution
         The value (in meV) to which ``sigma`` is set when the energy transfer is higher than
         `high_energy_cutoff`.
-    restrictions
-    defaults
     """
     fit: list[float]
     low_energy_cutoff: float = - np.inf

--- a/src/resolution_functions/models/pychop.py
+++ b/src/resolution_functions/models/pychop.py
@@ -81,11 +81,6 @@ class PyChopModelData(ModelData):
         Width of aperture at moderator face in meters (m)
     theta
         The angle that the beamline makes with the moderator face in degrees.
-    default_e_init
-        The default value for the initial energy (``e_init``) in meV.
-    allowed_e_init
-        The limits (lower and upper bound) for the allowed initial energies (``e_init``). This
-        should correspond to the physical limitations of the INS instrument.
     frequency_matrix
         A matrix mapping the relationship between the user-provided parameter ``chopper_frequency``
         or its equivalent (depending on model) to the frequency of each chopper in the instrument.
@@ -104,8 +99,6 @@ class PyChopModelData(ModelData):
     d_sample_detector: float
     aperture_width: float
     theta: float
-    default_e_init: float
-    allowed_e_init: list[float]
     frequency_matrix: list[list[float]]
     choppers: dict[str, FermiChopper | DiskChopper]
     moderator: Moderator
@@ -140,11 +133,6 @@ class PyChopModelDataFermi(PyChopModelData):
         Width of aperture at :term:`moderator` face in meters (m)
     theta
         The angle that the beamline makes with the :term:`moderator` face in degrees.
-    default_e_init
-        The default value for the initial energy (``e_init``) in meV.
-    allowed_e_init
-        The limits (lower and upper bound) for the allowed initial energies (``e_init``). This
-        should correspond to the physical limitations of the INS :term:`instrument`.
     frequency_matrix
         A matrix mapping the relationship between the user-provided parameter ``chopper_frequency``
         to the frequency of each :term:`chopper` in the :term:`instrument`.
@@ -158,12 +146,6 @@ class PyChopModelDataFermi(PyChopModelData):
         Data for the :term:`sample`. See `Sample` for more info.
     tjit
         The jitter time in microseconds (us).
-    default_chopper_frequency
-        The default value for the :term:`Fermi chopper` frequency (``chopper_frequency``) in Hz.
-    allowed_chopper_frequencies
-        The allowed values for the :term:`Fermi chopper` frequency (``chopper_frequency``) in Hz.
-        `allowed_chopper_frequencies` defines the (start, stop, step), which is converted into a
-        list at runtime.
     pslit
         Width of the neutron-transparent slit in meters (m).
     radius
@@ -171,8 +153,6 @@ class PyChopModelDataFermi(PyChopModelData):
     rho
         Curvature of the :term:`chopper` package in meters (m).
     """
-    default_chopper_frequency: int
-    allowed_chopper_frequencies: list[int]
     pslit: float
     radius: float
     rho: float
@@ -207,11 +187,6 @@ class PyChopModelDataNonFermi(PyChopModelData):
         Width of aperture at :term:`moderator` face in meters (m)
     theta
         The angle that the beamline makes with the :term:`moderator` face in degrees.
-    default_e_init
-        The default value for the initial energy (``e_init``) in meV.
-    allowed_e_init
-        The limits (lower and upper bound) for the allowed initial energies (``e_init``). This
-        should correspond to the physical limitations of the INS :term:`instrument`.
     frequency_matrix
         A matrix mapping the relationship between all user-provided :term:`chopper` frequency
         parameters (i.e. the choppers with user control) to the frequency of each :term:`chopper` in
@@ -226,13 +201,6 @@ class PyChopModelDataNonFermi(PyChopModelData):
         Data for the :term:`sample`. See `Sample` for more info.
     tjit
         The jitter time in microseconds (us).
-    default_chopper_frequency
-        The default value for the :term:`chopper` frequency of each user-controlled :term:`chopper`
-        in Hz.
-    allowed_chopper_frequencies
-        The allowed values for the :term:`chopper` frequency of each user-controlled
-        :term:`chopper`, in Hz. Each value defines the (start, stop, step), which is converted into
-        a list at runtime.
     constant_frequencies
         The frequency of each :term:`chopper` in Hz, with those run at a constant frequency having
         non-zero values.
@@ -241,8 +209,6 @@ class PyChopModelDataNonFermi(PyChopModelData):
     n_frame
         Number of frames to calculate time-distance diagram for.
     """
-    default_chopper_frequency: list[int]
-    allowed_chopper_frequencies: list[list[int]]
     constant_frequencies: list[int]
     source_frequency: float
     n_frame: int

--- a/src/resolution_functions/models/pychop.py
+++ b/src/resolution_functions/models/pychop.py
@@ -66,6 +66,13 @@ class PyChopModelData(ModelData):
         The name of the function, i.e. the alias for `PantherAbINSModel`.
     citation
         The citation for the model. Please use this to look up more details and cite the model.
+    restrictions
+        All constraints that the model places on the :term:`settings<setting>`. If the value is a
+        `list`, this signifies the `range` style (start, stop, step) tuple, and if it is a `set`, it
+        is a set of explicitly allowed values.
+    defaults
+        The default values for the :term:`settings<setting>`, used when a value is not provided when
+        creating the model.
     d_chopper_sample
         Distance from the final chopper to sample in meters (m).
     d_sample_detector
@@ -92,8 +99,6 @@ class PyChopModelData(ModelData):
         Data for the sample. See `Sample` for more info.
     tjit
         The jitter time in microseconds (us).
-    restrictions
-    defaults
     """
     d_chopper_sample: float
     d_sample_detector: float
@@ -120,6 +125,13 @@ class PyChopModelDataFermi(PyChopModelData):
         The name of the function, i.e. the alias for `PantherAbINSModel`.
     citation
         The citation for the model. Please use this to look up more details and cite the model.
+    restrictions
+        All constraints that the model places on the :term:`settings<setting>`. If the value is a
+        `list`, this signifies the `range` style (start, stop, step) tuple, and if it is a `set`, it
+        is a set of explicitly allowed values.
+    defaults
+        The default values for the :term:`settings<setting>`, used when a value is not provided when
+        creating the model.
     d_chopper_sample
         Distance from the final :term:`chopper` to :term:`sample` in meters (m).
     d_sample_detector
@@ -158,22 +170,12 @@ class PyChopModelDataFermi(PyChopModelData):
         Radius of the :term:`chopper` package in meters (m).
     rho
         Curvature of the :term:`chopper` package in meters (m).
-    restrictions
-    defaults
     """
     default_chopper_frequency: int
     allowed_chopper_frequencies: list[int]
     pslit: float
     radius: float
     rho: float
-
-    @property
-    def restrictions(self) -> dict[str, list[int | float]]:
-        return {'e_init': self.allowed_e_init, 'chopper_frequency': self.allowed_chopper_frequencies}
-
-    @property
-    def defaults(self) -> dict:
-        return {'e_init': self.default_e_init, 'chopper_frequency': self.default_chopper_frequency}
 
 
 @dataclass(init=True, repr=True, frozen=True, slots=True)
@@ -190,6 +192,13 @@ class PyChopModelDataNonFermi(PyChopModelData):
         The name of the function, i.e. the alias for `PantherAbINSModel`.
     citation
         The citation for the model. Please use this to look up more details and cite the model.
+    restrictions
+        All constraints that the model places on the :term:`settings<setting>`. If the value is a
+        `list`, this signifies the `range` style (start, stop, step) tuple, and if it is a `set`, it
+        is a set of explicitly allowed values.
+    defaults
+        The default values for the :term:`settings<setting>`, used when a value is not provided when
+        creating the model.
     d_chopper_sample
         Distance from the final :term:`chopper` to :term:`sample` in meters (m).
     d_sample_detector
@@ -231,22 +240,12 @@ class PyChopModelDataNonFermi(PyChopModelData):
         The frequency of the neutron :term:`source` in Hz.
     n_frame
         Number of frames to calculate time-distance diagram for.
-    restrictions
-    defaults
     """
     default_chopper_frequency: list[int]
     allowed_chopper_frequencies: list[list[int]]
     constant_frequencies: list[int]
     source_frequency: float
     n_frame: int
-
-    @property
-    def restrictions(self) -> dict[str, list[int | float]]:
-        return {'e_init': self.allowed_e_init, 'chopper_frequency': self.allowed_chopper_frequencies}
-
-    @property
-    def defaults(self) -> dict:
-        return {'e_init': self.default_e_init, 'chopper_frequency': self.default_chopper_frequency}
 
 
 class FermiChopper(TypedDict):

--- a/src/resolution_functions/models/pychop.py
+++ b/src/resolution_functions/models/pychop.py
@@ -979,15 +979,10 @@ class PyChopModelFermi(PyChopModel):
                  fitting_order: int = 4,
                  **_):
         super().__init__(model_data)
-        
-        if chopper_frequency is None:
-            chopper_frequency = model_data.default_chopper_frequency
-        elif chopper_frequency not in range(*model_data.allowed_chopper_frequencies):
-            raise InvalidInputError(f'The provided chopper frequency ({chopper_frequency}) is not '
-                                    f'allowed; only the following frequencies are possible: '
-                                    f'{list(range(*model_data.allowed_chopper_frequencies))}')
 
-        e_init = self._validate_e_init(e_init, model_data)
+        settings = self._validate_settings(model_data,
+                                           {'e_init': e_init, 'chopper_frequency': chopper_frequency})
+        e_init, chopper_frequency = settings['e_init'], settings['chopper_frequency']
 
         fake_frequencies, resolution = self._precompute_resolution(model_data, e_init, [chopper_frequency])
         self._polynomial = Polynomial.fit(fake_frequencies, resolution, fitting_order)
@@ -1064,45 +1059,6 @@ class PyChopModelNonFermi(PyChopModel, ABC):
     data_class = PyChopModelDataNonFermi
 
     @staticmethod
-    def _validate_chopper_frequency(chopper_frequencies: list[int | None],
-                                    model_data: PyChopModelDataNonFermi) -> list[int]:
-        """
-        Validates that the user-provided `chopper_frequencies` are among the allowed values for the instrument.
-
-        Parameters
-        ----------
-        chopper_frequencies
-            A list of chopper frequencies corresponding to the choppers with tunable frequencies.
-            The list must have the same length and order as the
-            `PyChopModelDataNonFermi.allowed_chopper_frequencies` for that instrument. Each entry
-            which contains a ``None`` instead of a value will be replaced with the default value
-            for the corresponding chopper.
-        model_data
-            The data for a particular INS instrument.
-
-        Returns
-        -------
-        chopper_frequencies
-            The valid chopper frequencies.
-
-        Raises
-        ------
-        InvalidInputError
-            If any of the provided `chopper_frequencies` is invalid.
-        """
-        for i, (frequency, allowed_chopper_frequencies) in (
-                enumerate(zip(chopper_frequencies, model_data.allowed_chopper_frequencies))):
-            if frequency is None:
-                chopper_frequencies[i] = model_data.default_chopper_frequency[i]
-            elif frequency not in range(*allowed_chopper_frequencies):
-                raise InvalidInputError(
-                    f'The provided chopper frequency ({frequency}) is not allowed; only the'
-                    f' following frequencies are possible: '
-                    f'{list(range(*allowed_chopper_frequencies))}')
-
-        return chopper_frequencies
-
-    @staticmethod
     def get_long_frequency(frequencies: list[int],
                            model_data: PyChopModelDataNonFermi
                            ) -> Float[np.ndarray, 'chopper_frequencies']:
@@ -1128,7 +1084,6 @@ class PyChopModelNonFermi(PyChopModel, ABC):
         all_frequencies
             The frequency of each chopper, in the order of increasing distance from the moderator.
         """
-        frequencies += model_data.default_chopper_frequency[len(frequencies):]
         frequency_matrix = np.array(model_data.frequency_matrix)
 
         return np.dot(frequency_matrix, frequencies) + model_data.constant_frequencies
@@ -1332,10 +1287,13 @@ class PyChopModelCNCS(PyChopModelNonFermi):
                  **_):
         super().__init__(model_data)
 
-        chopper_frequencies = [resolution_disk_frequency, fermi_frequency]
-        chopper_frequencies = self._validate_chopper_frequency(chopper_frequencies, model_data)
+        settings = {'e_init': e_init,
+                    'resolution_disk_frequency': resolution_disk_frequency,
+                    'fermi_frequency': fermi_frequency}
+        settings = self._validate_settings(model_data, settings)
 
-        e_init = self._validate_e_init(e_init, model_data)
+        e_init = settings['e_init']
+        chopper_frequencies = [settings['resolution_disk_frequency'], settings['fermi_frequency']]
 
         frequencies, resolution = self._precompute_resolution(model_data, e_init, chopper_frequencies)
         self._polynomial = Polynomial.fit(frequencies, resolution, fitting_order)
@@ -1407,10 +1365,14 @@ class PyChopModelLET(PyChopModelNonFermi):
                  **_):
         super().__init__(model_data)
 
-        chopper_frequencies = [resolution_frequency, pulse_remover_frequency]
-        chopper_frequencies = self._validate_chopper_frequency(chopper_frequencies, model_data)
+        settings = {'e_init': e_init,
+                    'resolution_frequency': resolution_frequency,
+                    'pulse_remover_frequency': pulse_remover_frequency}
+        settings = self._validate_settings(model_data, settings)
 
-        e_init = self._validate_e_init(e_init, model_data)
+        e_init = settings['e_init']
+        chopper_frequencies = [settings['resolution_frequency'],
+                               settings['pulse_remover_frequency']]
 
         frequencies, resolution = self._precompute_resolution(model_data, e_init, chopper_frequencies)
         self._polynomial = Polynomial.fit(frequencies, resolution, fitting_order)

--- a/src/resolution_functions/models/tosca_book.py
+++ b/src/resolution_functions/models/tosca_book.py
@@ -35,6 +35,13 @@ class ToscaBookModelData(ModelData):
         The name of the function, i.e. the alias for `PantherAbINSModel`.
     citation
         The citation for the model. Please use this to look up more details and cite the model.
+    restrictions
+        All constraints that the model places on the :term:`settings<setting>`. If the value is a
+        `list`, this signifies the `range` style (start, stop, step) tuple, and if it is a `set`, it
+        is a set of explicitly allowed values.
+    defaults
+        The default values for the :term:`settings<setting>`, used when a value is not provided when
+        creating the model.
     primary_flight_path
         Distance between the :term:`moderator` and the :term:`sample` in meters (m).
     primary_flight_path_uncertainty
@@ -65,8 +72,6 @@ class ToscaBookModelData(ModelData):
         Average Bragg angle of the graphite analyser, in degrees.
     change_average_bragg_angle_graphite
         Uncertainty associated with `average_bragg_angle_graphite`.
-    restrictions
-    defaults
     """
     primary_flight_path: float
     primary_flight_path_uncertainty: float

--- a/src/resolution_functions/models/vision_paper.py
+++ b/src/resolution_functions/models/vision_paper.py
@@ -35,6 +35,13 @@ class VisionPaperModelData(ModelData):
         The name of the function, i.e. the alias for `PantherAbINSModel`.
     citation
         The citation for the model. Please use this to look up more details and cite the model.
+    restrictions
+        All constraints that the model places on the :term:`settings<setting>`. If the value is a
+        `list`, this signifies the `range` style (start, stop, step) tuple, and if it is a `set`, it
+        is a set of explicitly allowed values.
+    defaults
+        The default values for the :term:`settings<setting>`, used when a value is not provided when
+        creating the model.
     primary_flight_path
         Distance between the :term:`moderator` and the :term:`sample` in meters (m).
     primary_flight_path_uncertainty
@@ -55,8 +62,6 @@ class VisionPaperModelData(ModelData):
         Distance between the :term:`sample` and the analyser, in meters (m).
     average_bragg_angle_graphite
         Average Bragg angle of the graphite analyser, in degrees.
-    restrictions
-    defaults
     """
     primary_flight_path: float
     primary_flight_path_uncertainty: float

--- a/tests/comparison_tests/unit_tests/test_pychop.py
+++ b/tests/comparison_tests/unit_tests/test_pychop.py
@@ -206,7 +206,8 @@ def let_data():
 def test_fermi_invalid_chopper_frequency(
     chopper_frequency, mari_data: tuple[PyChopModelDataFermi, PyChopInstrument]
 ):
-    with pytest.raises(InvalidInputError, match="The provided chopper frequency"):
+    with pytest.raises(InvalidInputError,
+                       match='The provided value for the "chopper_frequency" setting'):
         PyChopModelFermi(mari_data[0], chopper_frequency=chopper_frequency)
 
 
@@ -216,56 +217,56 @@ def test_fermi_invalid_chopper_frequency(
 def test_fermi_invalid_e_init(
     e_init, mari_data: tuple[PyChopModelDataFermi, PyChopInstrument]
 ):
-    with pytest.raises(InvalidInputError, match="The provided incident energy"):
+    with pytest.raises(InvalidInputError, match='The provided value for the "e_init" setting'):
         PyChopModelFermi(mari_data[0], e_init=e_init)
 
 @pytest.mark.parametrize(
-    "chopper_frequency",
+    'chopper_frequency,match',
     [
-        [59.99999, 60],
-        [-0.048] * 2,
-        [-np.inf, 0],
-        [120, 300.00017],
-        [np.inf, np.inf],
-        [300, np.nan],
-        [60.5, 60],
-        [180, 67.5],
-        [600, 600],
-        [130, 130],
-    ],
+        ([59.99999, 60], 'resolution_disk_frequency'),
+        ([-0.048] * 2, 'resolution_disk_frequency'),
+        ([-np.inf, 0], 'resolution_disk_frequency'),
+        ([120, 300.00017], 'fermi_frequency'),
+        ([np.inf, np.inf], 'resolution_disk_frequency'),
+        ([300, np.nan], 'fermi_frequency'),
+        ([60.5, 60], 'resolution_disk_frequency'),
+        ([180, 67.5], 'fermi_frequency'),
+        ([600, 600], 'resolution_disk_frequency'),
+        ([135, 135], 'resolution_disk_frequency')
+    ]
 )
-def test_cncs_invalid_chopper_frequency(chopper_frequency, cncs_data: PyChopModelDataNonFermi):
-    with pytest.raises(InvalidInputError, match="The provided chopper frequency"):
+def test_cncs_invalid_chopper_frequency(chopper_frequency, match, cncs_data: PyChopModelDataNonFermi):
+    with pytest.raises(InvalidInputError, match=f'The provided value for the "{match}" setting'):
         PyChopModelCNCS(cncs_data, resolution_disk_frequency=chopper_frequency[0], fermi_frequency=chopper_frequency[1])
 
 
 @pytest.mark.parametrize('e_init', [-5, -0.00048, -np.inf, 80.1, np.inf, 13554.1654, np.nan])
 def test_cncs_invalid_e_init(e_init, cncs_data: PyChopModelDataNonFermi):
-    with pytest.raises(InvalidInputError, match="The provided incident energy"):
+    with pytest.raises(InvalidInputError, match='The provided value for the "e_init" setting'):
         PyChopModelCNCS(cncs_data, e_init=e_init)
 
 
 @pytest.mark.parametrize(
-    'chopper_frequency',
-    [[59.99999, 60],
-     [-0.048] * 2,
-     [-np.inf, 0],
-     [120, 300.00017],
-     [np.inf, np.inf],
-     [300, np.nan],
-     [60.5, 60],
-     [180, 67.5],
-     [600, 600],
-     [135, 135]]
+    'chopper_frequency,match',
+    [([59.99999, 60], 'resolution_frequency'),
+     ([-0.048] * 2, 'resolution_frequency'),
+     ([-np.inf, 0], 'resolution_frequency'),
+     ([120, 300.00017], 'pulse_remover_frequency'),
+     ([np.inf, np.inf], 'resolution_frequency'),
+     ([300, np.nan], 'pulse_remover_frequency'),
+     ([60.5, 60], 'resolution_frequency'),
+     ([180, 67.5], 'pulse_remover_frequency'),
+     ([600, 600], 'resolution_frequency'),
+     ([135, 135], 'resolution_frequency')]
 )
-def test_let_invalid_chopper_frequency(chopper_frequency, let_data: PyChopModelDataNonFermi):
-    with pytest.raises(InvalidInputError, match="The provided chopper frequency"):
+def test_let_invalid_chopper_frequency(chopper_frequency, match, let_data: PyChopModelDataNonFermi):
+    with pytest.raises(InvalidInputError, match=f'The provided value for the "{match}" setting'):
         PyChopModelLET(let_data, resolution_frequency=chopper_frequency[0], pulse_remover_frequency=chopper_frequency[1])
 
 
 @pytest.mark.parametrize('e_init', [-5, -0.00048, -np.inf, 30.0001, np.inf, 13554.1654, np.nan])
 def test_let_invalid_e_init(e_init, let_data: PyChopModelDataNonFermi):
-    with pytest.raises(InvalidInputError, match="The provided incident energy"):
+    with pytest.raises(InvalidInputError, match='The provided value for the "e_init" setting'):
         PyChopModelLET(let_data, e_init=e_init)
 
 

--- a/tests/comparison_tests/unit_tests/test_pychop.py
+++ b/tests/comparison_tests/unit_tests/test_pychop.py
@@ -604,11 +604,22 @@ def _test_precompute_resolution(e_init, chopper_frequency, cls, data, pychop):
     try:
         pychop.chopper_system.setFrequency(chopper_frequency)
     except ValueError as e:
+        try:
+            pychop.chopper_system.setEi(e_init)
+        except ValueError as e:
+            if f'Ei={e_init} is outside limits ' in str(e):
+                with pytest.raises(InvalidInputError,
+                                   match=rf'The provided value for the "e_init" setting \({e_init}\)'):
+                    cls(model_data=data, chopper_frequency=chopper_frequency, e_init=e_init)
+                return
+            raise
+
         if 'Value of frequencies outside maximum allowed' in str(e):
             # Energy out of range for Pychop: make sure the model agrees
             with pytest.raises(
                     InvalidInputError,
-                    match=rf"The provided chopper frequency \(\[{chopper_frequency[0]}\]\) is not allowed"):
+                    match=rf'The provided value for the "chopper_frequency" setting '
+                          rf'\(\[{chopper_frequency[0]}\]\) must be within'):
                 cls(model_data=data, chopper_frequency=chopper_frequency, e_init=e_init)
 
             return

--- a/tests/comparison_tests/unit_tests/test_pychop.py
+++ b/tests/comparison_tests/unit_tests/test_pychop.py
@@ -221,7 +221,7 @@ def test_fermi_invalid_e_init(
         PyChopModelFermi(mari_data[0], e_init=e_init)
 
 @pytest.mark.parametrize(
-    'chopper_frequency,match',
+    'chopper_frequency,invalid_setting',
     [
         ([59.99999, 60], 'resolution_disk_frequency'),
         ([-0.048] * 2, 'resolution_disk_frequency'),
@@ -235,8 +235,8 @@ def test_fermi_invalid_e_init(
         ([135, 135], 'resolution_disk_frequency')
     ]
 )
-def test_cncs_invalid_chopper_frequency(chopper_frequency, match, cncs_data: PyChopModelDataNonFermi):
-    with pytest.raises(InvalidInputError, match=f'The provided value for the "{match}" setting'):
+def test_cncs_invalid_chopper_frequency(chopper_frequency, invalid_setting, cncs_data: PyChopModelDataNonFermi):
+    with pytest.raises(InvalidInputError, match=f'The provided value for the "{invalid_setting}" setting'):
         PyChopModelCNCS(cncs_data, resolution_disk_frequency=chopper_frequency[0], fermi_frequency=chopper_frequency[1])
 
 
@@ -247,7 +247,7 @@ def test_cncs_invalid_e_init(e_init, cncs_data: PyChopModelDataNonFermi):
 
 
 @pytest.mark.parametrize(
-    'chopper_frequency,match',
+    'chopper_frequency,invalid_setting',
     [([59.99999, 60], 'resolution_frequency'),
      ([-0.048] * 2, 'resolution_frequency'),
      ([-np.inf, 0], 'resolution_frequency'),
@@ -259,8 +259,8 @@ def test_cncs_invalid_e_init(e_init, cncs_data: PyChopModelDataNonFermi):
      ([600, 600], 'resolution_frequency'),
      ([135, 135], 'resolution_frequency')]
 )
-def test_let_invalid_chopper_frequency(chopper_frequency, match, let_data: PyChopModelDataNonFermi):
-    with pytest.raises(InvalidInputError, match=f'The provided value for the "{match}" setting'):
+def test_let_invalid_chopper_frequency(chopper_frequency, invalid_setting, let_data: PyChopModelDataNonFermi):
+    with pytest.raises(InvalidInputError, match=f'The provided value for the "{invalid_setting}" setting'):
         PyChopModelLET(let_data, resolution_frequency=chopper_frequency[0], pulse_remover_frequency=chopper_frequency[1])
 
 

--- a/tests/unit_tests/fake_instrument.yaml
+++ b/tests/unit_tests/fake_instrument.yaml
@@ -17,6 +17,9 @@ version:
                     val1: 1
                     val2: 2
                 non_dict: 3
+            defaults: {}
+            restrictions:
+                kwarg2: [0]
         configurations: &version1_configurations
             config1:
                 default_option: "A"
@@ -59,7 +62,9 @@ version:
             empty_v1:
                 function: "none"
                 citation: [""]
-                parameters: {}
+                parameters:
+                    defaults: {}
+                    restrictions: {}
                 configurations: {}
     TEST:
         default_model: "invalid model"
@@ -68,5 +73,7 @@ version:
             mock_v1:
                 function: "mock"
                 citation: [""]
-                parameters: {}
+                parameters:
+                    defaults: {}
+                    restrictions: {}
                 configurations: {}

--- a/tests/unit_tests/test_instrument.py
+++ b/tests/unit_tests/test_instrument.py
@@ -28,10 +28,6 @@ class MockModelData(ModelData):
     matrix: list[list[int]]
     dictionary: dict[str, dict[str, int] | int]
 
-    @property
-    def restrictions(self) -> dict[str, list[int | float]]:
-        return {'kwarg2': [0]}
-
 
 class MockModel(InstrumentModel):
     input = 1

--- a/tests/unit_tests/test_model_base.py
+++ b/tests/unit_tests/test_model_base.py
@@ -1,0 +1,119 @@
+import re
+import pytest
+
+from resolution_functions.models.model_base import InstrumentModel, InvalidInputError
+
+
+class MockModel(InstrumentModel):
+    def get_characteristics(self, *args):
+        return {}
+
+    def __call__(self, *args, **kwargs):
+        return
+
+
+class MockModelData:
+    function = ''
+    citation = ['']
+
+    def __init__(self, defaults, restrictions):
+        self.defaults = defaults
+        self.restrictions = restrictions
+
+
+@pytest.fixture(scope='module')
+def model():
+    class MockData:
+        citation = ['']
+
+    return MockModel(MockData())
+
+
+def test_validate_settings_default(model):
+    default = 100
+    model_data = MockModelData({'setting': default}, {})
+
+    result = model._validate_settings(model_data, {'setting': None})
+    assert result['setting'] == default
+
+
+def test_validate_settings_no_default(model):
+    model_data = MockModelData({}, {})
+
+    with pytest.raises(InvalidInputError,
+                       match='Model "MockModel" does not have a default value for the "no_default"'):
+        model._validate_settings(model_data, {'no_default': None})
+
+
+def test_validate_settings_default_skips_restrictions(model):
+    default = 100
+    model_data = MockModelData({'setting': default}, {'setting': [0, 1]})
+
+    result = model._validate_settings(model_data, {'setting': None})
+    assert result['setting'] == default
+
+
+def test_validate_settings_default_not_applied_when_value(model):
+    value = 100
+    model_data = MockModelData({'setting': 333}, {})
+
+    result = model._validate_settings(model_data, {'setting': value})
+    assert result['setting'] == value
+
+
+def test_validate_settings_restriction_list2_works(model):
+    value = 50
+    model_data = MockModelData({}, {'setting': [0, 100]})
+
+    result = model._validate_settings(model_data, {'setting': value})
+    assert result['setting'] == value
+
+
+def test_validate_settings_restriction_list2_raises(model):
+    model_data = MockModelData({}, {'setting': [0, 100]})
+
+    with pytest.raises(InvalidInputError,
+                       match=re.escape('The provided value for the "setting" setting (500) must be '
+                                       'within the [0, 100] boundaries.')):
+        model._validate_settings(model_data, {'setting': 500})
+
+
+def test_validate_settings_restriction_list3_works(model):
+    value = 200
+    model_data = MockModelData({}, {'setting': [100, 500, 100]})
+
+    result = model._validate_settings(model_data, {'setting': value})
+    assert result['setting'] == value
+
+
+def test_validate_settings_restriction_list3(model):
+    model_data = MockModelData({}, {'setting': [100, 500, 100]})
+
+    with pytest.raises(InvalidInputError,
+                       match=re.escape('The provided value for the "setting" setting (500) must be '
+                                       'one of the following values: [100, 200, 300, 400]')):
+        model._validate_settings(model_data, {'setting': 500})
+
+
+def test_validate_settings_restriction_list_wrong_length(model):
+    model_data = MockModelData({}, {'setting': [100]})
+
+    with pytest.raises(ValueError):
+        model._validate_settings(model_data, {'setting': 500})
+
+
+def test_validate_settings_restriction_set_works(model):
+    value = 200
+    model_data = MockModelData({}, {'setting': {100, 200, 300, 400}})
+
+    result = model._validate_settings(model_data, {'setting': value})
+    assert result['setting'] == value
+
+
+def test_validate_settings_restriction_set_raises(model):
+    model_data = MockModelData({}, {'setting': {100, 200, 300, 400}})
+
+    with pytest.raises(InvalidInputError,
+                       match=r'The provided value for the \"setting\" setting \(500\) must be one '
+                             r'of the following values: {.+}'):
+        model._validate_settings(model_data, {'setting': 500})


### PR DESCRIPTION
Resolves #23 

- Structures the YAML data so that the restrictions and defaults are inside new dictionaries instead of using prefixes for names. 
- Makes it a requirement for each model to have the `restrictions` and `defaults` keys in its `parameters` dictionary (and therefore changes the YAML spec in #19). 
- Implements a generic (universal) validator for settings, though it is a bit clunky due to the need for passing dictionaries around (could be avoided by standardising the settings
- Some of the tests had to be manhandled a little bit due to the changes in the error messages and validation order