### PR TITLE
Use PyPI version of inline_reference

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ test = [
 docs = [
     "sphinx >= 8.1.3",
     "numpydoc >= 1.8.0",
-    "inline_reference @ git+https://github.com/pace-neutrons/inline_reference.git",
+    "inline_reference",
     "sphinx_parsed_codeblock @ git+https://github.com/RastislavTuranyi/sphinx_parsed_codeblock.git",
     "sphinx_rtd_theme >= 3.0.2",
 ]


### PR DESCRIPTION
Since we have [released](https://github.com/pace-neutrons/inline_reference/releases/tag/v1.0.0) the `inline_reference` sphinx extension on [PyPI](https://pypi.org/project/inline-reference/), I think we should switch our pyproject.toml to refer to that instead of the GitHub directly.